### PR TITLE
Fixes broken skeleton app and body-parser deprecation warning

### DIFF
--- a/generators/app/templates/_app/_app.js
+++ b/generators/app/templates/_app/_app.js
@@ -12,7 +12,7 @@ app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'ejs');
 
 app.use(bodyParser.json());
-app.use(bodyParser.urlencoded());
+app.use(bodyParser.urlencoded({ extended: true }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
 

--- a/generators/app/templates/_app/_public/_js/_app.js
+++ b/generators/app/templates/_app/_public/_js/_app.js
@@ -4,5 +4,6 @@ angular.module('app', [])
         $scope.person = {};
         $scope.add = function() {
             $scope.people.push($scope.person);
+            $scope.person = {};
         };
     });

--- a/generators/app/templates/_app/_views/_index.ejs
+++ b/generators/app/templates/_app/_views/_index.ejs
@@ -33,8 +33,8 @@
                         <th>Age</th>
                     </tr>
                     <tr ng-repeat="p in people">
-                        <td ng-bind="p.name"></td>
-                        <td ng-bind="p.age"></td>
+                        <td>{{p.name}}</td>
+                        <td>{{p.age}}</td>
                     </tr>
                 </table>
             </div>


### PR DESCRIPTION
The skeleton app that comes with the generator was broken. To reproduce:

```bash
npm install -g generator-wean
mkdir test && cd test
yo wean
grunt
```

Then click the "Add" button to observe the following error:

```bash
[8934:1027/182414:INFO:CONSOLE(12450)] ""Error: [ngRepeat:dupes] Duplicates in a repeater are not allowed. Use 'track by' expression to specify unique keys. Repeater: p in people, Duplicate key: object:6, Duplicate value: ...
```

Also fixes `body-parser deprecated urlencoded` deprecation warning.